### PR TITLE
Fix hangover's build error.

### DIFF
--- a/windows-user/main.c
+++ b/windows-user/main.c
@@ -23,7 +23,6 @@
 #include "qemu/osdep.h"
 #include "qemu-version.h"
 
-#include <wine/library.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
 #include <delayloadhandler.h>

--- a/windows-user/pe.c
+++ b/windows-user/pe.c
@@ -147,6 +147,34 @@ static FARPROC find_named_export( HMODULE module, const IMAGE_EXPORT_DIRECTORY *
 static NTSTATUS qemu_LdrUnloadDll( HMODULE hModule );
 static WCHAR *MODULE_get_dll_load_path(const WCHAR *module);
 
+/* workaround for wine:6ca76dc5e73733d7fb8212a614bf093cd49da342 */
+/*
+ * Wine internal Unicode definitions
+ *
+ * Copyright 2000 Alexandre Julliard
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+static inline WCHAR *memrchrW( const WCHAR *ptr, WCHAR ch, size_t n )
+{
+    const WCHAR *end;
+    WCHAR *ret = NULL;
+    for (end = ptr + n; ptr < end; ptr++) if (*ptr == ch) ret = (WCHAR *)(ULONG_PTR)ptr;
+    return ret;
+}
+
 /* convert PE image VirtualAddress to Real Address */
 static inline void *get_rva( HMODULE module, DWORD va )
 {

--- a/windows-user/pe.c
+++ b/windows-user/pe.c
@@ -28,7 +28,6 @@
 #include "qemu-version.h"
 
 #include <wine/port.h>
-#include <wine/library.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
 #include <wine/exception.h>

--- a/windows-user/win_syscall.c
+++ b/windows-user/win_syscall.c
@@ -19,7 +19,6 @@
 #include "config.h"
 
 #include <wine/port.h>
-#include <wine/library.h>
 #include <wine/debug.h>
 
 #include "qemu/osdep.h"


### PR DESCRIPTION
Some files and functions have been deleted on latest Wine. This PR fix some build error of the hangover (https://github.com/AndreRH/hangover/commit/f16ec8fd7d58589a7ae4ba10144d3b1f7c587468). However, the hangover still causes other build error.